### PR TITLE
Fix pydantic version - pydantic update causing errors in bittensor library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pydantic==2.9.2
 bittensor==7.0.2
 torch==2.3.0
 pandas==2.2.2


### PR DESCRIPTION
After a new release of pydantic (2.10.x), the bittensor library started to malfunction.
https://pypi.org/project/pydantic/
Bittensor doesn't use a fixed version of pydantic and after the pydantic update, it was trying to access a deprecated attribute.

https://github.com/opentensor/bittensor/blob/master/requirements/prod.txt#L22
`pydantic>=2.3, <3`

